### PR TITLE
Add FileSet type that is like a file type, but instead of updating a sing

### DIFF
--- a/Form/DataTransformer/FileSetTransformer.php
+++ b/Form/DataTransformer/FileSetTransformer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Comways\FormExtraBundle\Form\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * Turn any value recieved from the fileset field into a null value.
+ * 
+ * @author Benjamin Eberlei <eberlei@simplethings.de>
+ */
+class FileSetTransformer implements DataTransformerInterface
+{
+    public function reverseTransform($value)
+    {
+        return $value;
+    }
+    
+    public function transform($value)
+    {
+        return "";
+    }
+}

--- a/Form/Type/FileSetType.php
+++ b/Form/Type/FileSetType.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Comways\FormExtraBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType; 
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Comways\FormExtraBundle\Form\DataTransformer\FileSetTransformer;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+/**
+ * Extends the File type not to handle a single file, but allowing to incrementally add one more file to a set.
+ * 
+ * @example:
+ *     $builder->add('attachments', 'fileset');
+ * 
+ * @author Benjamin Eberlei <eberlei@simplethings.de>
+ */
+class FileSetType extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder->prependNormTransformer(new FileSetTransformer());
+        $builder->setAttribute('delete_route', $options['delete_route']);
+        $builder->setAttribute('delete_id', $options['delete_id']);
+    }
+    
+    public function buildView(FormView $view, FormInterface $form)
+    {
+        $data = $form->getData();        
+        if (!is_array($data)) {
+            throw new UnexpectedTypeException($data, 'array');
+        }
+        
+        $files = array();
+        foreach ($data AS $file) {
+            if ($file instanceof File) {
+                $files[] = basename($file->getPath());
+            } else if (is_string($file)) {
+                $files[] = basename($file);
+            } else {
+                throw new \RuntimeException("Expecting an instance of File or string.");
+            }
+        }
+        $view->set('files', $files);
+        $view->set('delete_route', $form->getAttribute('delete_route'));
+        $view->set('delete_id', $form->getAttribute('delete_id'));
+    }
+    
+    public function getDefaultOptions(array $options)
+    {
+        return array(
+            'delete_route' => false,
+            'delete_id' => false,
+        );
+    }
+    
+    public function getName()
+    {
+        return 'fileset';
+    }
+    
+    public function getParent(array $options)
+    {
+        return 'file';
+    }
+}

--- a/Form/Type/FileSetType.php
+++ b/Form/Type/FileSetType.php
@@ -34,13 +34,13 @@ class FileSetType extends AbstractType
         }
         
         $files = array();
-        foreach ($data AS $file) {
+        foreach ($data as $file) {
             if ($file instanceof File) {
                 $files[] = basename($file->getPath());
             } else if (is_string($file)) {
                 $files[] = basename($file);
             } else {
-                throw new \RuntimeException("Expecting an instance of File or string.");
+                throw new UnexpectedTypeException($file, 'string');
             }
         }
         $view->set('files', $files);

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ This bundle contains additional functionality for Symfony2's Form Component.
 Currently this Bundle provides the following:
 
 * RecaptchaFieldType for using Google's reCAPTCHA service.
+* ImageType for showing the previously uploaded image
+* FileSet for showing a list of previously uplaoded files
 * FieldTypeExtension for allowing setting `attr` when building a Form.
 
 Current this Bundle **does not** provide the following:
 
 * In depth documentation.
-* Tests
 * Unicorns or other fairytale creatures.
 
 Contributors

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ parameters:
 ## FileSetType
 
 `FileSetType` allows you to incrementally add more files to a collection of files by extending
-the `FileType`. It render an unordered list of all the previously uploaded base filenames.
+the `FileType`. It renders an unordered list of all the previously uploaded base filenames.
 
-Instead of return the previously added file you return an array of all file names
+Instead of returning the previously added file you return an array of all file names
 from the fields getter method and in the setter method you append the newly uploaded file to the collection:
 
 ``` php
@@ -123,6 +123,7 @@ class Document
 Using the builder to create a field for this type would then look like:
 
 ``` php
+<?php
 $builder->add('newAttachment', 'fileset', array(
     'type' => 'file',
 ));

--- a/README.md
+++ b/README.md
@@ -82,6 +82,57 @@ parameters:
     comways_form_extra.service.recaptcha.class: Comways\FormExtraBundle\FunctionalTest\Recaptcha
 ```
 
+## FileSetType
+
+`FileSetType` allows you to incrementally add more files to a collection of files by extending
+the `FileType`. It render an unordered list of all the previously uploaded base filenames.
+
+Instead of return the previously added file you return an array of all file names
+from the fields getter method and in the setter method you append the newly uploaded file to the collection:
+
+``` php
+<?php
+class Document
+{
+    // temporary field, used in the form, to move new attachments to persistence
+    private $newAttachment;
+    // persistent array with all attachments.
+    private $attachments;
+
+    public function getNewAttachment()
+    {
+        $files = array();
+        foreach ($this->attachments AS $attachment) {
+            $files[] = $attachment->getFilename();
+        }
+        return $files;
+    }
+
+    public function setNewAttachment(File $newAttachment = null)
+    {
+        $this->newAttachment = $newAttachment;
+    }
+
+    public function moveNewAttachment()
+    {
+        // code to move file and include in the attachments field.
+    }
+}
+```
+
+Using the builder to create a field for this type would then look like:
+
+``` php
+$builder->add('newAttachment', 'fileset', array(
+    'type' => 'file',
+));
+```
+
+There are optional parameters 'delete_route' and 'delete_id' which are then used with twigs path
+method to generate a route with parameters "id" and "file", to delete the listed file. If the information
+passed is not enough you should overwrite the twig template with your own logic to implement
+deleting.
+
 ### FieldTypeExtension
 
 A Field Extension contains method called by FormBuilder or createView. Theese applies to all fields

--- a/Resources/config/form_extra.xml
+++ b/Resources/config/form_extra.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="comways_form_extra.form.type.recaptcha.class">Comways\FormExtraBundle\Form\Type\RecaptchaType</parameter>
         <parameter key="comways_form_extra.form.type.image.class">Comways\FormExtraBundle\Form\Type\ImageType</parameter>
+        <parameter key="comways_form_extra.form.type.fileset.class">Comways\FormExtraBundle\Form\Type\FileSetType</parameter>
         <parameter key="comways_form_extra.form.extension.field.class">Comways\FormExtraBundle\Form\Extension\FieldTypeExtension</parameter>
         <parameter key="comways_form_extra.service.recaptcha.class">Comways\FormExtraBundle\Service\Recaptcha</parameter>
     </parameters>
@@ -25,6 +26,10 @@
         
         <service id="comways_form_extra.form.type.image" class="%comways_form_extra.form.type.image.class%" scope="request">
             <tag name="form.type" alias="image" />
+        </service>
+        
+        <service id="comways_form_extra.form.type.fileset" class="%comways_form_extra.form.type.fileset.class%" scope="request">
+            <tag name="form.type" alias="fileset" />
         </service>
 
         <service id="comways_form_extra.form.extension.field" class="%comways_form_extra.form.extension.field.class%">

--- a/Resources/views/Form/div_layout.html.twig
+++ b/Resources/views/Form/div_layout.html.twig
@@ -31,3 +31,25 @@
     </div>
 {% endspaceless %}
 {% endblock %}
+
+{% block fileset_widget %}
+    <ul>
+    {% for file in files %}
+        {% spaceless %}
+        <li>
+            {{ file }}
+            {% if delete_route is not empty and delete_id is not empty %}
+                <a href="{{ path(delete_route, {"id": delete_id, "file": file}) }}">[{% trans %}Delete{% endtrans %}]</a>
+            {% endif %}
+        </li>
+        {% endspaceless %}
+    {% endfor %}
+    </ul>
+
+    <div {{ block('container_attributes') }}>
+        {{ form_widget(form.file) }}
+        {{ form_widget(form.token) }}
+        {{ form_widget(form.name) }}
+        {{ form_widget(form.originalName) }}
+    </div>
+{% endblock %}


### PR DESCRIPTION
Add FileSet type that is like a file type, but instead of updating a single file the getter is supposed to return an array of file names, the setter appends new files to the array. The form widget renders with an unordered list of already uplaoded files.
