### PR TITLE
Add fallback autoloader for standalone bundle testing

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -10,3 +10,12 @@ $loader->registerNamespaces(array(
     'Symfony' => $_SERVER['SYMFONY'],
 ));
 $loader->register();
+
+spl_autoload_register(function($class) {
+    if (0 === strpos($class, 'SimpleThings\\FormExtraBundle')) {
+        $file = dirname(__DIR__).str_replace('\\', DIRECTORY_SEPARATOR, substr($class, strlen('SimpleThings\\FormExtraBundle'))) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    }
+}, true);


### PR DESCRIPTION
The default autoload configuration in Tests/bootstrap.php does not load properly since UniversalClassLoader always generate the path from the class name.

Not sure if this is the nicest workaround, but it works if you want to run phpunit from a direct git clone.
