### PR TITLE
Normalize directory separator in image_uri

### DIFF
--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -57,6 +57,9 @@ class ImageType extends AbstractType
         if ($data && (strpos($data->getPath(), $form->getAttribute('base_path')) === 0)) {
             /* @var $data SplFileInfo */
             $uri = str_replace($form->getAttribute('base_path'), $form->getAttribute('base_uri'), $data->getRealPath());
+            if ('/' !== DIRECTORY_SEPARATOR) {
+                $uri = str_replace(DIRECTORY_SEPARATOR, '/', $uri);
+            }
             $view->set('image_uri', $uri);
         } else if ($form->hasAttribute ('no_image_placeholder_uri') && $uri = $form->getAttribute ('no_image_placeholder_uri')) {
             $view->setAttribute('image_uri', $uri);


### PR DESCRIPTION
Fixes the following test failing on Windows:

```
1) SimpleThings\FormExtraBundle\Tests\Form\Type\ImageFormTypeTest::testBuildView
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-http://example.com/ImageTypeTest.php
+http://example.com\ImageTypeTest.php
```
