### PR TITLE
Make (recaptcha) config optional

### DIFF
--- a/DependencyInjection/SimpleThingsFormExtraExtension.php
+++ b/DependencyInjection/SimpleThingsFormExtraExtension.php
@@ -18,8 +18,13 @@ class SimpleThingsFormExtraExtension extends Extension
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(), $configs);
 
-        $container->getDefinition('simple_things_form_extra.service.recaptcha')->replaceArgument(1, $config['recaptcha']['private_key']);
-        $container->getDefinition('simple_things_form_extra.form.type.recaptcha')->replaceArgument(1, $config['recaptcha']['public_key']);
+        if (isset($config['recaptcha']['private_key'])) {
+            $container->getDefinition('simple_things_form_extra.service.recaptcha')->replaceArgument(1, $config['recaptcha']['private_key']);
+        }
+
+        if (isset($config['recaptcha']['public_key'])) {
+            $container->getDefinition('simple_things_form_extra.form.type.recaptcha')->replaceArgument(1, $config['recaptcha']['public_key']);
+        }
     }
 
     public function getAlias()

--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\HttpFoundation\Request;
 
 use SimpleThings\FormExtraBundle\Service\Recaptcha;
@@ -57,6 +58,10 @@ class RecaptchaType extends AbstractType
      */
     public function buildForm(FormBuilder $builder, array $options)
     {
+        if ((string) $this->publicKey === '') {
+            throw new FormException('A public key must be set and not empty.');
+        }
+
         $builder
             ->add('recaptcha_challenge_field', 'text')
             ->add('recaptcha_response_field', 'hidden', array(

--- a/Tests/DependencyInjection/SimpleThingsFormExtraExtensionTest.php
+++ b/Tests/DependencyInjection/SimpleThingsFormExtraExtensionTest.php
@@ -44,4 +44,11 @@ class SimpleThingsFormExtraExtensionTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($container->hasDefinition('simple_things_form_extra.' . $definition));
         }
     }
+
+    public function testLoadAllowsEmptyConfig()
+    {
+        $container = new ContainerBuilder();
+        $extension = new SimpleThingsFormExtraExtension();
+        $extension->load(array(array()), $container);
+    }
 }


### PR DESCRIPTION
I do not want to use the `RecaptchaType`. This PR makes the whole `simple_things_form_extra` configuration optional.

Not sure if the `SimpleThings\FormExtraBundle\Service\Recaptcha` and `SimpleThings\FormExtraBundle\Form\Type\RecaptchaType`should now throw an exception if public/private keys are empty.
