### PR TITLE
ImageType Bugfixes (use of assetic, possibility to overwrite twig, realpath for base_url)

### DIFF
--- a/DependencyInjection/Compiler/TwigFormPass.php
+++ b/DependencyInjection/Compiler/TwigFormPass.php
@@ -19,8 +19,8 @@ class TwigFormPass implements CompilerPassInterface
         }
 
         $container->setParameter('twig.form.resources', array_merge(
-            $container->getParameter('twig.form.resources'),
-            array('SimpleThingsFormExtraBundle:Form:div_layout.html.twig')
+            array('SimpleThingsFormExtraBundle:Form:div_layout.html.twig'),
+            $container->getParameter('twig.form.resources')
         ));
     }
 }

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -56,7 +56,7 @@ class ImageType extends AbstractType
         
         if ($data && (strpos($data->getPath(), $form->getAttribute('base_path')) === 0)) {
             /* @var $data SplFileInfo */
-            $uri = str_replace($form->getAttribute('base_path'), $form->getAttribute('base_uri'), $data->getRealPath());
+            $uri = str_replace(realpath($form->getAttribute('base_path')), $form->getAttribute('base_uri'), $data->getRealPath());
             if ('/' !== DIRECTORY_SEPARATOR) {
                 $uri = str_replace(DIRECTORY_SEPARATOR, '/', $uri);
             }

--- a/Resources/views/Form/div_layout.html.twig
+++ b/Resources/views/Form/div_layout.html.twig
@@ -17,7 +17,7 @@
 {% spaceless %}
     <div class="form_image">
         {% if image_uri is defined %}
-        <img src="{{ image_uri }}" alt="{{ image_alt }}"{% if image_height > 0 %} height="{{ image_height }}"{% endif %}{% if image_width > 0 %} width="{{ image_width }}"{% endif %}/>
+        <img src="{{ asset(image_uri) }}" alt="{{ image_alt }}"{% if image_height > 0 %} height="{{ image_height }}"{% endif %}{% if image_width > 0 %} width="{{ image_width }}"{% endif %}/>
         {% else %}
         {% trans %}No image uploaded.{% endtrans %}
         {% endif %}


### PR DESCRIPTION
Possibility to overwrite formextra twig blocks
Realpath for base_path to replace correctly in image type
Use of asset in image type
