### PR TITLE
fix plain form type, clean use statements, add phpdocs

### DIFF
--- a/Form/Type/PlainType.php
+++ b/Form/Type/PlainType.php
@@ -3,28 +3,38 @@
 namespace SimpleThings\FormExtraBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilder;
+
 
 /**
  * A Form type that just renders the field as a p tag. This is useful for forms where certain field
  * need to be shown but not editable.
  *
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
+ * @author Gordon Franke <info@nevalon.de>
  */
 class PlainType extends AbstractType
 {
     /**
-     * @param array $options
-     * @return array
+     * {@inheritdoc}
+     */
+    public function getParent(array $options)
+    {
+        return 'field';
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function getDefaultOptions(array $options)
     {
         return array(
-            'read_only' => true,
-            'property_path' => false,
+            'read_only' => true
         );
     }
-    
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'formextra_plain';


### PR DESCRIPTION
With Symfony 2.0.15 the plain form type doesn't display any data. So i fix this.
