### PR TITLE
Fixed: typo in docs + added deps description

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ $ git clone git://github.com/SimpleThings/SimpleThingsFormExtraBundle.git vendor
 $ git submodule add git://github.com/SimpleThings/SimpleThingsFormExtraBundle.git vendor/bundles/SimpleThings/FormExtraBundle
 ```
 
+``` deps
+[FormExtraBundle]
+    git=https://github.com/simplethings/SimpleThingsFormExtraBundle.git
+    target=bundles/SimpleThings/FormExtraBundle
+
+
 the enable to the bundle inside your kernel class normally called `AppKernel.php`
 
 ``` php
@@ -176,7 +182,7 @@ To use it, you need to activate it and to register the form theme using the tran
 ``` yaml
 # app/config/config.yml
 simple_things_form_extra:
-    translation_domain_forward_campat: true
+    translation_domain_forward_compat: true
 
 twig:
     form:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $ git submodule add git://github.com/SimpleThings/SimpleThingsFormExtraBundle.gi
 [FormExtraBundle]
     git=https://github.com/simplethings/SimpleThingsFormExtraBundle.git
     target=bundles/SimpleThings/FormExtraBundle
+```
 
 
 the enable to the bundle inside your kernel class normally called `AppKernel.php`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ $ git clone git://github.com/SimpleThings/SimpleThingsFormExtraBundle.git vendor
 $ git submodule add git://github.com/SimpleThings/SimpleThingsFormExtraBundle.git vendor/bundles/SimpleThings/FormExtraBundle
 ```
 
+or use the deps file by adding this in it and running php bin/vendors install
+
 ``` deps
 [FormExtraBundle]
     git=https://github.com/simplethings/SimpleThingsFormExtraBundle.git


### PR DESCRIPTION
I've added deps lines and description for installing + fixed a typo in translation_domain_forward_campat - compat is the correct one.
