### PR TITLE
[WIP] Form Serializer Extension

### DIFF
--- a/Form/EventListener/BindRequestListener.php
+++ b/Form/EventListener/BindRequestListener.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * SimpleThings FormExtraBundle
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormExtraBundle\Form\EventListener;
+
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+use SimpleThings\FormExtraBundle\Serializer\EncoderRegistry;
+use SimpleThings\FormExtraBundle\Serializer\NamingStrategy\CamelCaseStrategy;
+
+class BindRequestListener implements EventSubscriberInterface
+{
+    private $encoderRegistry;
+    private $namingStrategy;
+
+    public function __construct(EncoderRegistry $encoderRegistry)
+    {
+        $this->encoderRegistry = $encoderRegistry;
+        $this->namingStrategy  = new CamelCaseStrategy();
+    }
+
+    public static function getSubscribedEvents()
+    {
+        // High priority in order to supersede other listeners
+        return array(FormEvents::PRE_BIND => array('preBind', 129));
+    }
+
+    public function preBind(FormEvent $event)
+    {
+        $form    = $event->getForm();
+        $request = $event->getData();
+
+        if ( ! $request instanceof Request) {
+            return;
+        }
+
+        $format = $request->getContentType();
+
+        if ( ! $this->encoderRegistry->supportsEncoding($format)) {
+            return;
+        }
+
+        $content = $request->getContent();
+        $data    = $this->encoderRegistry
+                        ->getEncoder($format)
+                        ->decode($content, $format);
+
+        $event->setData($this->unserializeForm($data, $form));
+    }
+
+    private function unserializeForm($data, $form)
+    {
+        if ( ! $form->hasChildren()) {
+            return $data;
+        }
+
+        $result = array();
+
+        foreach ($form->getChildren() as $child) {
+            $options     = $child->getConfig()->getOptions();
+            $name        = $this->namingStrategy->translateName($child);
+            $isAttribute = isset($options['serialize_attribute']) && $options['serialize_attribute'];
+            $value       = isset($data['@' . $name])
+                ? $data['@' . $name]
+                : (isset($data[$name]) ? $data[$name] : null);
+
+            $result[$child->getName()] = $this->unserializeForm($value, $child);
+        }
+
+        return $result;
+    }
+}
+

--- a/Form/Extension/SerializerTypeExtension.php
+++ b/Form/Extension/SerializerTypeExtension.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * SimpleThings FormExtraBundle
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormExtraBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+use SimpleThings\FormExtraBundle\Form\EventListener\BindRequestListener;
+
+class SerializerTypeExtension extends AbstractTypeExtension
+{
+    private $encoderRegistry;
+
+    public function __construct($encoderRegistry)
+    {
+        $this->encoderRegistry = $encoderRegistry;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addEventSubscriber(new BindRequestListener($this->encoderRegistry));
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'serialize_xml_root' => 'entry',
+            'serialize_attribute' => false,
+        ));
+    }
+
+    public function getExtendedType()
+    {
+        return 'form';
+    }
+}
+

--- a/Form/SerializerExtension.php
+++ b/Form/SerializerExtension.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Beberlei Form Serializer
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormExtraBundle\Form;
+
+use Symfony\Component\Form\Extension\Core\Type;
+use Symfony\Component\Form\AbstractExtension;
+
+use SimpleThings\FormExtraBundle\Form\Extension\SerializerTypeExtension;
+
+class SerializerExtension extends AbstractExtension
+{
+    private $encoderRegistry;
+
+    public function __construct($encoderRegistry)
+    {
+        $this->encoderRegistry = $encoderRegistry;
+    }
+
+    protected function loadTypeExtensions()
+    {
+        return array(new SerializerTypeExtension($this->encoderRegistry));
+    }
+}
+

--- a/Serializer/EncoderRegistry.php
+++ b/Serializer/EncoderRegistry.php
@@ -13,13 +13,27 @@
 
 namespace SimpleThings\FormExtraBundle\Serializer;
 
-class EncoderRegistry
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+
+class EncoderRegistry implements EncoderInterface, DecoderInterface
 {
     private $encoders = array();
 
     public function __construct(array $encoders)
     {
         $this->encoders = $encoders;
+    }
+
+    public function supportsDecoding($format)
+    {
+        foreach ($this->encoders as $encoder) {
+            if ($encoder->supportsDecoding($format)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function supportsEncoding($format)
@@ -31,6 +45,18 @@ class EncoderRegistry
         }
 
         return false;
+    }
+
+    public function decode($data, $format)
+    {
+        $encoder = $this->getEncoder($format);
+        return $encoder->decode($data, $format);
+    }
+
+    public function encode($data, $format)
+    {
+        $encoder = $this->getEncoder($format);
+        return $encoder->encode($data, $format);
     }
 
     public function getEncoder($format)

--- a/Serializer/EncoderRegistry.php
+++ b/Serializer/EncoderRegistry.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * SimpleThings FormExtraBundle
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormExtraBundle\Serializer;
+
+class EncoderRegistry
+{
+    private $encoders = array();
+
+    public function __construct(array $encoders)
+    {
+        $this->encoders = $encoders;
+    }
+
+    public function supportsEncoding($format)
+    {
+        foreach ($this->encoders as $encoder) {
+            if ($encoder->supportsEncoding($format)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getEncoder($format)
+    {
+        foreach ($this->encoders as $encoder) {
+            if ($encoder->supportsEncoding($format)) {
+                return $encoder;
+            }
+        }
+
+        throw new \RuntimeException("No encoder for $format");
+    }
+}
+

--- a/Serializer/FormSerializer.php
+++ b/Serializer/FormSerializer.php
@@ -16,20 +16,22 @@ namespace SimpleThings\FormExtraBundle\Serializer;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\TypeInterface;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
 
 use SimpleThings\FormExtraBundle\Serializer\NamingStrategy\CamelCaseStrategy;
+use SimpleThings\FormExtraBundle\Serializer\NamingStrategy\NamingStrategy;
 
 class FormSerializer
 {
     private $factory;
-    private $encoderRegistry;
+    private $encoder;
     private $namingStrategy;
 
-    public function __construct(FormFactoryInterface $factory, EncoderRegistry $encoderRegistry)
+    public function __construct(FormFactoryInterface $factory, EncoderInterface $encoder, NamingStrategy $namingStrategy = null)
     {
-        $this->factory         = $factory;
-        $this->encoderRegistry = $encoderRegistry;
-        $this->namingStrategy  = new CamelCaseStrategy();
+        $this->factory        = $factory;
+        $this->encoder        = $encoder;
+        $this->namingStrategy = $namingStrategy ?: new CamelCaseStrategy();
     }
 
     public function serialize($object, $typeBuilder, $format)
@@ -50,10 +52,9 @@ class FormSerializer
 
         $data = $this->serializeForm($form, $format == 'xml');
 
-        $this->encoderRegistry->getEncoder('xml')->setRootNodeName($xmlName);
+        $this->encoder->getEncoder('xml')->setRootNodeName($xmlName);
 
-        return $this->encoderRegistry
-                    ->getEncoder($format)
+        return $this->encoder
                     ->encode($data, $format);
     }
 

--- a/Serializer/FormSerializer.php
+++ b/Serializer/FormSerializer.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * SimpleThings FormExtraBundle
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormExtraBundle\Serializer;
+
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\TypeInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+
+use SimpleThings\FormExtraBundle\Serializer\NamingStrategy\CamelCaseStrategy;
+
+class FormSerializer
+{
+    private $factory;
+    private $encoderRegistry;
+    private $namingStrategy;
+
+    public function __construct(FormFactoryInterface $factory, EncoderRegistry $encoderRegistry)
+    {
+        $this->factory         = $factory;
+        $this->encoderRegistry = $encoderRegistry;
+        $this->namingStrategy  = new CamelCaseStrategy();
+    }
+
+    public function serialize($object, $typeBuilder, $format)
+    {
+        if ($typeBuilder instanceof TypeInterface) {
+            $form = $this->factory->create($typeBuilder, $object);
+        } else if ($typeBuilder instanceof FormBuilderInterface) {
+            $form = $typeBuilder->getForm();
+            $form->setData($object);
+        } else {
+            throw new \RuntimeException();
+        }
+
+        $options = $form->getConfig()->getOptions();
+        $xmlName = isset($options['serialize_xml_root'])
+            ? $options['serialize_xml_root']
+            : 'entry';
+
+        $data = $this->serializeForm($form, $format == 'xml');
+
+        $this->encoderRegistry->getEncoder('xml')->setRootNodeName($xmlName);
+
+        return $this->encoderRegistry
+                    ->getEncoder($format)
+                    ->encode($data, $format);
+    }
+
+    private function serializeForm($form, $isXml)
+    {
+        if ( ! $form->hasChildren()) {
+            return $form->getViewData();
+        }
+
+        foreach ($form->getChildren() as $child) {
+            $options = $child->getConfig()->getOptions();
+            $name    = $this->namingStrategy->translateName($child);
+            $name    = $isXml && $options['serialize_attribute'] ? '@' . $name : $name;
+
+            $data[$name] = $this->serializeForm($child, $isXml);
+        }
+
+        return $data;
+    }
+}
+

--- a/Serializer/NamingStrategy/CamelCaseStrategy.php
+++ b/Serializer/NamingStrategy/CamelCaseStrategy.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * SimpleThings FormExtraBundle
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormExtraBundle\Serializer\NamingStrategy;
+
+use Symfony\Component\Form\FormInterface;
+
+class CamelCaseStrategy implements NamingStrategy
+{
+    public function translateName(FormInterface $form)
+    {
+        return strtolower(preg_replace('/[A-Z]/', '_\\0', $form->getName()));
+    }
+}
+

--- a/Serializer/NamingStrategy/NamingStrategy.php
+++ b/Serializer/NamingStrategy/NamingStrategy.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * SimpleThings FormExtraBundle
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormExtraBundle\Serializer\NamingStrategy;
+
+use Symfony\Component\Form\FormInterface;
+
+interface NamingStrategy
+{
+    function translateName(FormInterface $form);
+}
+

--- a/Tests/Serializer/FormSerializerTest.php
+++ b/Tests/Serializer/FormSerializerTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * SimpleThings FormExtraBundle
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace SimpleThings\FormExtraBundle\Tests\Serializer;
+
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormRegistry;
+use Symfony\Component\Form\Extension\Core\CoreExtension;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\HttpFoundation\Request;
+
+use SimpleThings\FormExtraBundle\Serializer\FormSerializer;
+use SimpleThings\FormExtraBundle\Serializer\EncoderRegistry;
+use SimpleThings\FormExtraBundle\Form\SerializerExtension;
+
+class FormSerializerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFunctional()
+    {
+        $registry = new EncoderRegistry(array(new XmlEncoder, new JsonEncoder));
+        $factory = new FormFactory(new FormRegistry(array(
+                        new CoreExtension(),
+                        new SerializerExtension($registry)
+                        )));
+
+        $address          = new Address();
+        $address->street  = "Somestreet 1";
+        $address->zipCode = 12345;
+        $address->city    = "Bonn";
+
+        $user           = new User();
+        $user->username = "beberlei";
+        $user->email    = "kontakt@beberlei.de";
+        $user->birthday = new \DateTime("1984-03-18");
+        $user->country  = "DE";
+        $user->address  = $address;
+
+        $builder = $factory->createBuilder('form', null, array('data_class' => __NAMESPACE__ . '\\User', 'serialize_xml_root' => 'user'));
+        $builder
+            ->add('username', 'text')
+            ->add('email', 'email')
+            ->add('birthday', 'date', array('widget' => 'single_text'))
+            ->add('country', 'country')
+            ->add('address', null, array('compound' => true, 'data_class' => __NAMESPACE__ . '\\Address'))
+            ;
+
+        $addressBuilder = $builder->get('address');
+        $addressBuilder
+            ->add('street', 'text', array('serialize_attribute' => true))
+            ->add('zipCode', 'text', array('serialize_attribute' => true))
+            ->add('city', 'text', array('serialize_attribute' => true))
+            ;
+
+        $formSerializer = new FormSerializer($factory, $registry);
+        $xml           = $formSerializer->serialize($user, $builder, 'xml');
+
+        $dom = new \DOMDocument;
+        $dom->loadXml($xml);
+        $dom->formatOutput = true;
+
+        /*
+           <?xml version="1.0"?>
+           <user>
+           <username>beberlei</username>
+           <email>kontakt@beberlei.de</email>
+           <birthday>1984-03-18</birthday>
+           <country>DE</country>
+           <address street="Somestreet 1" zip_code="12345" city="Bonn"/>
+           </user>
+         */
+
+        $json = $formSerializer->serialize($user, $builder, 'json');
+        /*
+           {
+           "username":"beberlei",
+           "email":"kontakt@beberlei.de",
+           "birthday":"1984-03-18",
+           "country":"DE",
+           "address":{"street":"Somestreet 1","zip_code":"12345","city":"Bonn"}
+           }*/
+
+        $user2 = new User;
+        $form = $builder->getForm();
+        $form->setData($user2);
+
+        $request = new Request(array(), array(),array(),array(),array(),array(
+                    'CONTENT_TYPE' => 'text/xml',
+                    ), $xml);
+
+        $form->bind($request);
+
+        $user3 = new User;
+        $form = $builder->getForm();
+        $form->setData($user3);
+
+        $request = new Request(array(), array(),array(),array(),array(),array(
+                    'CONTENT_TYPE' => 'application/json',
+                    ), $json);
+        $form->bind($request);
+
+        $this->assertEquals($user2, $user);
+        $this->assertEquals($user3, $user);
+    }
+}
+
+class User
+{
+    public $username;
+    public $email;
+    public $country;
+    public $birthday;
+    public $addresses;
+    public $created;
+    public $address;
+}
+
+class Address
+{
+    public $street;
+    public $zipCode;
+    public $city;
+}


### PR DESCRIPTION
This form extension allows to serialize object graphs from form types, and bind serialized data to forms. Currently supported:
- XML
- JSON

See the Functional test for an example how to setup and json/xml serialization/deserialization.

To deserialize just use the form framework, nothing different than the usual:

```
public function editAction(Request $request)
{
    $user = $this->get('doctrine.orm.default_entity_manager')
                 ->find('Acme\DemoBundle\Entity\User', $request->get('id'));
    $form = $this->createForm(new UserType(), $user);

    if ($request->getMethod() === 'POST') {
        // detects+decodes Content-Type: application/json and text/xml
        $form->bind($request);

        if ($form->isValid()) {
            // do stuff
        }
    }

    return array('form' => $form->createView(), 'user' => $user);
}
```

To serialize:

```
public function viewAction(Request $request)
{
    $user = $this->get('doctrine.orm.default_entity_manager')
                 ->find('Acme\DemoBundle\Entity\User', $request->get('id'));

    $serializer = $this->get('form_serializer');
    $xml = $serializer->serialize($user, new UserType(), 'xml');

    return new Response($xml, 200, array('Content-Type' => 'text/xml'));
}
```

WIP:
- Missing actual wiring in the Container.
- Support for XML namespaces
- Support for Link Relations
- Serialize Only PlainText Type (Read-Only, Read+Write)
