### PR TITLE
Fix "*" composer definition in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ or for symfony 2.1 add this to your composer.json and run composer install
 ``` json
 {
     "require": {
-        "simplethings/form-extra-bundle": "*"
+        "simplethings/form-extra-bundle": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
"simplethings/form-extra-bundle": "*" will download version 0.1 which will not work with Symfony2.1
