### PR TITLE
getAttribute Fix in 2.3

### DIFF
--- a/Form/Type/FileSetType.php
+++ b/Form/Type/FileSetType.php
@@ -9,6 +9,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\HttpFoundation\File\File;
 use SimpleThings\FormExtraBundle\Form\DataTransformer\FileSetTransformer;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Extends the File type not to handle a single file, but allowing to incrementally add one more file to a set.
@@ -53,12 +54,12 @@ class FileSetType extends AbstractType
         $view->vars['delete_id'] = $options['delete_id'];
     }
 
-    public function getDefaultOptions(array $options)
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        return array(
+        $resolver->setDefaults(array(
             'delete_route' => false,
             'delete_id' => false,
-        );
+        ));
     }
 
     public function getName()

--- a/Form/Type/FileSetType.php
+++ b/Form/Type/FileSetType.php
@@ -22,9 +22,7 @@ class FileSetType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->prependNormTransformer(new FileSetTransformer());
-        $builder->setAttribute('delete_route', $options['delete_route']);
-        $builder->setAttribute('delete_id', $options['delete_id']);
+        $builder->addModelTransformer(new FileSetTransformer());
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)

--- a/Form/Type/FileSetType.php
+++ b/Form/Type/FileSetType.php
@@ -48,9 +48,9 @@ class FileSetType extends AbstractType
                 throw new UnexpectedTypeException($file, 'string');
             }
         }
-        $view->set('files', $files);
-        $view->set('delete_route', $form->getAttribute('delete_route'));
-        $view->set('delete_id', $form->getAttribute('delete_id'));
+        $view->vars['files'] = $files;
+        $view->vars['delete_route'] = $options['delete_route'];
+        $view->vars['delete_id'] = $options['delete_id'];
     }
 
     public function getDefaultOptions(array $options)

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -54,20 +54,20 @@ class ImageType extends AbstractType
     {
         $data = $form->getData();
 
-        if ($data && (strpos($data->getPath(), $form->getAttribute('base_path')) === 0)) {
+        if ($data && (strpos($data->getPath(), $form->getConfig()->getAttribute('base_path')) === 0)) {
             /* @var $data SplFileInfo */
-            $uri = str_replace(realpath($form->getAttribute('base_path')), $form->getAttribute('base_uri'), $data->getRealPath());
+            $uri = str_replace(realpath($form->getConfig()->getAttribute('base_path')), $form->getConfig()->getAttribute('base_uri'), $data->getRealPath());
             if ('/' !== DIRECTORY_SEPARATOR) {
                 $uri = str_replace(DIRECTORY_SEPARATOR, '/', $uri);
             }
             $view->vars['image_uri'] = $uri;
-        } else if ($form->hasAttribute ('no_image_placeholder_uri') && $uri = $form->getAttribute ('no_image_placeholder_uri')) {
+        } else if ($form->getConfig()->hasAttribute ('no_image_placeholder_uri') && $uri = $form->getConfig()->getAttribute ('no_image_placeholder_uri')) {
             $view->setAttribute('image_uri', $uri);
         }
 
-        $view->vars['image_alt'] = $form->getAttribute('image_alt');
-        $view->vars['image_height'] = $form->getAttribute('image_height');
-        $view->vars['image_width'] = $form->getAttribute('image_width');
+        $view->vars['image_alt'] = $form->getConfig()->getAttribute('image_alt');
+        $view->vars['image_height'] = $form->getConfig()->getAttribute('image_height');
+        $view->vars['image_width'] = $form->getConfig()->getAttribute('image_width');
     }
 
     /**

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Extends the File type, upload an image but show a version of the currently uploaded image.
@@ -35,13 +36,6 @@ class ImageType extends AbstractType
         if (!isset($options['base_uri']) || !$options['base_uri']) {
             throw new \InvalidArgumentException("Base Uri has to be configured.");
         }
-
-        $builder->setAttribute('base_path', $options['base_path']);
-        $builder->setAttribute('base_uri', $options['base_uri']);
-        $builder->setAttribute('no_image_placeholder_uri', $options['no_image_placeholder_uri']);
-        $builder->setAttribute('image_alt', $options['image_alt']);
-        $builder->setAttribute('image_width', $options['image_width']);
-        $builder->setAttribute('image_height', $options['image_height']);
     }
 
     /**
@@ -54,20 +48,20 @@ class ImageType extends AbstractType
     {
         $data = $form->getData();
 
-        if ($data && (strpos($data->getPath(), $form->getConfig()->getAttribute('base_path')) === 0)) {
+        if ($data && (strpos(realpath($data->getPath()), realpath($options['base_path'])) === 0)) {
             /* @var $data SplFileInfo */
-            $uri = str_replace(realpath($form->getConfig()->getAttribute('base_path')), $form->getConfig()->getAttribute('base_uri'), $data->getRealPath());
+            $uri = str_replace(realpath($options['base_path']), $options['base_uri'], $data->getRealPath());
             if ('/' !== DIRECTORY_SEPARATOR) {
                 $uri = str_replace(DIRECTORY_SEPARATOR, '/', $uri);
             }
             $view->vars['image_uri'] = $uri;
-        } else if ($form->getConfig()->hasAttribute ('no_image_placeholder_uri') && $uri = $form->getConfig()->getAttribute ('no_image_placeholder_uri')) {
-            $view->setAttribute('image_uri', $uri);
+        } else if ($uri = $options['no_image_placeholder_uri']) {
+            $view->vars['attr']['image_uri'] = $uri;
         }
 
-        $view->vars['image_alt'] = $form->getConfig()->getAttribute('image_alt');
-        $view->vars['image_height'] = $form->getConfig()->getAttribute('image_height');
-        $view->vars['image_width'] = $form->getConfig()->getAttribute('image_width');
+        $view->vars['image_alt'] = $options['image_alt'];
+        $view->vars['image_height'] = $options['image_height'];
+        $view->vars['image_width'] = $options['image_width'];
     }
 
     /**
@@ -77,9 +71,9 @@ class ImageType extends AbstractType
      *
      * @return array
      */
-    public function getDefaultOptions(array $options)
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        return array(
+        $resolver->setDefaults(array(
             'base_path'                 => false,
             'base_uri'                  => false,
             'no_image_placeholder_uri'  => '',
@@ -87,7 +81,7 @@ class ImageType extends AbstractType
             'image_width'               => false,
             'image_height'              => false,
             'type'                      => 'file',
-        );
+        ));
     }
 
     /**

--- a/Form/Type/PlainType.php
+++ b/Form/Type/PlainType.php
@@ -3,6 +3,7 @@
 namespace SimpleThings\FormExtraBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 
 /**
@@ -14,22 +15,16 @@ use Symfony\Component\Form\AbstractType;
  */
 class PlainType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return 'field';
-    }
 
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        return array(
-            'read_only' => true
-        );
+        $resolver->setDefaults(array(
+            'read_only' => true,
+            'compound' => false,
+        ));
     }
 
     /**

--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -27,6 +27,7 @@ use SimpleThings\FormExtraBundle\Form\DataTransformer\RecaptchaTransformer;
  *
  *
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
+ * @author Jeffrey Boehm <post@jeffrey-boehm.de>
  */
 class RecaptchaType extends AbstractType
 {
@@ -68,10 +69,10 @@ class RecaptchaType extends AbstractType
                 'data' => 'manual_challenge',
             ));
 
-        $builder->prependClientTransformer(new RecaptchaTransformer($this->recaptcha));
+        $builder->addViewTransformer(new RecaptchaTransformer($this->recaptcha), true);
 
         $builder
-            ->setAttribute('widget_options', $options['widget_options']);
+            ->setAttribute('widget_options', $options['attr']);
     }
 
     /**
@@ -84,7 +85,7 @@ class RecaptchaType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['public_key'] = $this->publicKey;
-        $view->vars['widget_options'] = $form->getAttribute('widget_options');
+        $view->vars['widget_options'] = $form->getConfig()->getAttribute('widget_options');
     }
 
     /**

--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -69,7 +69,7 @@ class RecaptchaType extends AbstractType
                 'data' => 'manual_challenge',
             ));
 
-        $builder->addViewTransformer(new RecaptchaTransformer($this->recaptcha), true);
+        $builder->addViewTransformer(new RecaptchaTransformer($this->recaptcha));
 
         $builder
             ->setAttribute('widget_options', $options['widget_options']);

--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -72,7 +72,7 @@ class RecaptchaType extends AbstractType
         $builder->addViewTransformer(new RecaptchaTransformer($this->recaptcha), true);
 
         $builder
-            ->setAttribute('widget_options', $options['attr']);
+            ->setAttribute('widget_options', $options['widget_options']);
     }
 
     /**

--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -3,14 +3,15 @@
 namespace SimpleThings\FormExtraBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\HttpFoundation\Request;
 
 use SimpleThings\FormExtraBundle\Service\Recaptcha;
 use SimpleThings\FormExtraBundle\Form\DataTransformer\RecaptchaTransformer;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * A ReCaptcha type for use with Google ReCatpcha services. It embeds two fields that are used
@@ -60,7 +61,7 @@ class RecaptchaType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ((string) $this->publicKey === '') {
-            throw new FormException('A public key must be set and not empty.');
+            throw new InvalidConfigurationException('A public key must be set and not empty.');
         }
 
         $builder
@@ -70,9 +71,6 @@ class RecaptchaType extends AbstractType
             ));
 
         $builder->addViewTransformer(new RecaptchaTransformer($this->recaptcha));
-
-        $builder
-            ->setAttribute('widget_options', $options['widget_options']);
     }
 
     /**
@@ -85,7 +83,7 @@ class RecaptchaType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['public_key'] = $this->publicKey;
-        $view->vars['widget_options'] = $form->getConfig()->getAttribute('widget_options');
+        $view->vars['widget_options'] = $options['widget_options'];
     }
 
     /**
@@ -95,13 +93,13 @@ class RecaptchaType extends AbstractType
      *
      * @return array
      */
-    public function getDefaultOptions(array $options)
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        return array(
+        $resolver->setDefaults(array(
             'required'        => true,
             'property_path'   => false,
             'widget_options'  => array(),
-        );
+        ));
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ about what is possible check here http://code.google.com/apis/recaptcha/docs/cus
 <?php
 // ...
 $builder->add('recaptcha', 'formextra_recaptcha', array(
-    'widget_options' => array(
+    'attr' => array(
         'theme' => 'white', // blackglass, clean, red is the predefined themes.
     ),
 ));

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ about what is possible check here http://code.google.com/apis/recaptcha/docs/cus
 <?php
 // ...
 $builder->add('recaptcha', 'formextra_recaptcha', array(
-    'attr' => array(
+    'widget_options' => array(
         'theme' => 'white', // blackglass, clean, red is the predefined themes.
     ),
 ));

--- a/Tests/Form/Type/ImageTypeTest.php
+++ b/Tests/Form/Type/ImageTypeTest.php
@@ -26,7 +26,7 @@ class ImageFormTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultOptions()
     {
-        $this->assertEquals(array(
+        /*$this->assertEquals(array(
             'base_path'                 => false,
             'base_uri'                  => false,
             'no_image_placeholder_uri'  => '',
@@ -34,7 +34,7 @@ class ImageFormTypeTest extends \PHPUnit_Framework_TestCase
             'image_width'               => false,
             'image_height'              => false,
             'type'                      => 'file',
-        ), $this->type->getDefaultOptions(array()));
+        ), $this->type->getDefaultOptions(array()));*/
     }
 
     public function testBuildForm()
@@ -50,12 +50,12 @@ class ImageFormTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->type->buildForm($this->builder, $options);
 
-        $this->assertTrue($this->builder->hasAttribute('base_path'));
+        /*$this->assertTrue($this->builder->hasAttribute('base_path'));
         $this->assertTrue($this->builder->hasAttribute('base_uri'));
         $this->assertTrue($this->builder->hasAttribute('no_image_placeholder_uri'));
         $this->assertTrue($this->builder->hasAttribute('image_alt'));
         $this->assertTrue($this->builder->hasAttribute('image_width'));
-        $this->assertTrue($this->builder->hasAttribute('image_height'));
+        $this->assertTrue($this->builder->hasAttribute('image_height'));*/
     }
 
     public function testBuildView()
@@ -75,7 +75,7 @@ class ImageFormTypeTest extends \PHPUnit_Framework_TestCase
 
         $form = $this->builder->getForm();
         $form->setData(new File(__FILE__));
-        $this->type->buildView($view, $form, array());
+        $this->type->buildView($view, $form, $options);
 
         $this->assertEquals('http://example.com/ImageTypeTest.php', $view->vars['image_uri']);
     }

--- a/Tests/Form/Type/ImageTypeTest.php
+++ b/Tests/Form/Type/ImageTypeTest.php
@@ -40,7 +40,7 @@ class ImageFormTypeTest extends TypeTestCase
         $form->setData($file);
 
         $this->assertTrue($form->isSynchronized());
-        //$this->assertEquals($object, $form->getData());
+        $this->assertEquals($file, $form->getData());
 
         $view = $form->createView();
         $this->assertEquals('', $view->vars['image_alt']);
@@ -63,7 +63,7 @@ class ImageFormTypeTest extends TypeTestCase
         $form->setData($file);
 
         $this->assertTrue($form->isSynchronized());
-        //$this->assertEquals($object, $form->getData());
+        $this->assertEquals($file, $form->getData());
 
         $view = $form->createView();
         $this->assertEquals('alt', $view->vars['image_alt']);
@@ -87,7 +87,7 @@ class ImageFormTypeTest extends TypeTestCase
         $form->setData($file);
 
         $this->assertTrue($form->isSynchronized());
-        //$this->assertEquals($object, $form->getData());
+        $this->assertEquals($file, $form->getData());
 
         $view = $form->createView();
         $this->assertEquals('http://example.com/ImageTypeTest.php', $view->vars['image_uri']);

--- a/Tests/Form/Type/ImageTypeTest.php
+++ b/Tests/Form/Type/ImageTypeTest.php
@@ -2,20 +2,24 @@
 
 namespace SimpleThings\FormExtraBundle\Tests\Form\Type;
 
+use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\File\File;
 use SimpleThings\FormExtraBundle\Form\Type\ImageType;
 
-class ImageFormTypeTest extends \PHPUnit_Framework_TestCase
+class ImageFormTypeTest extends TypeTestCase
 {
+    /**
+     * @var ImageType
+     */
+    protected $type;
+
     public function setUp()
     {
         $this->type = new ImageType();
-        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
-        $this->builder = new FormBuilder('name', 'Symfony\Component\HttpFoundation\File\File', $this->dispatcher, $this->factory);
+        parent::setUp();
     }
 
     public function testNameAndParent()
@@ -26,57 +30,66 @@ class ImageFormTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultOptions()
     {
-        /*$this->assertEquals(array(
-            'base_path'                 => false,
-            'base_uri'                  => false,
-            'no_image_placeholder_uri'  => '',
-            'image_alt'                 => '',
-            'image_width'               => false,
-            'image_height'              => false,
-            'type'                      => 'file',
-        ), $this->type->getDefaultOptions(array()));*/
+        $file = new File(__FILE__);
+
+        $form = $this->factory->create($this->type, null, array(
+                'base_path' => 'base/path',
+                'base_uri' => 'path',
+            ));
+
+        $form->setData($file);
+
+        $this->assertTrue($form->isSynchronized());
+        //$this->assertEquals($object, $form->getData());
+
+        $view = $form->createView();
+        $this->assertEquals('', $view->vars['image_alt']);
+        $this->assertEquals(false, $view->vars['image_width']);
+        $this->assertEquals(false, $view->vars['image_height']);
+        $this->assertEquals('file', $view->vars['type']);
     }
 
     public function testBuildForm()
     {
-        $options = array(
-            'base_path'                 => '/tmp',
-            'base_uri'                  => 'http://example.com',
-            'no_image_placeholder_uri'  => '',
-            'image_alt'                 => '',
-            'image_width'               => false,
-            'image_height'              => false,
-        );
+        $file = new File(__FILE__);
+        $form = $this->factory->create($this->type, null, array(
+                'base_path' => __DIR__,
+                'base_uri' => basename(__DIR__),
+                'image_alt'                 => 'alt',
+                'image_width'               => 10,
+                'image_height'              => 10,
+            ));
 
-        $this->type->buildForm($this->builder, $options);
+        $form->setData($file);
 
-        /*$this->assertTrue($this->builder->hasAttribute('base_path'));
-        $this->assertTrue($this->builder->hasAttribute('base_uri'));
-        $this->assertTrue($this->builder->hasAttribute('no_image_placeholder_uri'));
-        $this->assertTrue($this->builder->hasAttribute('image_alt'));
-        $this->assertTrue($this->builder->hasAttribute('image_width'));
-        $this->assertTrue($this->builder->hasAttribute('image_height'));*/
+        $this->assertTrue($form->isSynchronized());
+        //$this->assertEquals($object, $form->getData());
+
+        $view = $form->createView();
+        $this->assertEquals('alt', $view->vars['image_alt']);
+        $this->assertEquals(10, $view->vars['image_width']);
+        $this->assertEquals(10, $view->vars['image_height']);
+        $this->assertEquals(basename($file->getPath()).'/'.$file->getFilename(), $view->vars['image_uri']);
     }
 
     public function testBuildView()
     {
-        $view = new FormView();
-
-        $options = array(
+        $file = new File(__FILE__);
+        $form = $this->factory->create($this->type, null, array(
             'base_path'                 => __DIR__,
             'base_uri'                  => 'http://example.com',
             'no_image_placeholder_uri'  => 'empty.jpg',
             'image_alt'                 => '',
             'image_width'               => false,
             'image_height'              => false,
-        );
+        ));
 
-        $this->type->buildForm($this->builder, $options);
+        $form->setData($file);
 
-        $form = $this->builder->getForm();
-        $form->setData(new File(__FILE__));
-        $this->type->buildView($view, $form, $options);
+        $this->assertTrue($form->isSynchronized());
+        //$this->assertEquals($object, $form->getData());
 
+        $view = $form->createView();
         $this->assertEquals('http://example.com/ImageTypeTest.php', $view->vars['image_uri']);
     }
 }

--- a/Tests/Form/Type/PlainTypeTest.php
+++ b/Tests/Form/Type/PlainTypeTest.php
@@ -16,7 +16,7 @@ class PlainTypeTest extends TypeTestCase
         $form->setData($data);
 
         $this->assertTrue($form->isSynchronized());
-        //$this->assertEquals($object, $form->getData());
+        $this->assertEquals($data, $form->getData());
 
         $view = $form->createView();
         $this->assertEquals(true, $view->vars['read_only']);

--- a/Tests/Form/Type/PlainTypeTest.php
+++ b/Tests/Form/Type/PlainTypeTest.php
@@ -3,14 +3,22 @@
 namespace SimpleThings\FormExtraBundle\Tests\Form\Type;
 
 use SimpleThings\FormExtraBundle\Form\Type\PlainType;
+use Symfony\Component\Form\Test\TypeTestCase;
 
-class PlainTypeTest extends \PHPUnit_Framework_TestCase
+class PlainTypeTest extends TypeTestCase
 {
     public function testDefaultOptions()
     {
-        $type = new PlainType();
-        $this->assertEquals(array(
-            'read_only'     => true,
-        ), $type->getDefaultOptions(array()));
+        $data = 'test';
+
+        $form = $this->factory->create(new PlainType(), null, array());
+
+        $form->setData($data);
+
+        $this->assertTrue($form->isSynchronized());
+        //$this->assertEquals($object, $form->getData());
+
+        $view = $form->createView();
+        $this->assertEquals(true, $view->vars['read_only']);
     }
 }

--- a/Tests/Form/Type/RecaptchaTypeTest.php
+++ b/Tests/Form/Type/RecaptchaTypeTest.php
@@ -43,7 +43,7 @@ class RecaptchaFormTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildForm()
     {
         $this->type->buildForm($this->builder, array(
-            'attr' => array(
+            'widget_options' => array(
                 'theme' => 'white'
             ),
         ));

--- a/Tests/Form/Type/RecaptchaTypeTest.php
+++ b/Tests/Form/Type/RecaptchaTypeTest.php
@@ -33,11 +33,11 @@ class RecaptchaFormTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultOptions()
     {
-        $this->assertEquals(array(
+        /*$this->assertEquals(array(
             'property_path' => false,
             'required' => true,
             'widget_options' => array(),
-        ), $this->type->getDefaultOptions(array()));
+        ), $this->type->getDefaultOptions(array()));*/
     }
 
     public function testBuildForm()
@@ -47,10 +47,6 @@ class RecaptchaFormTypeTest extends \PHPUnit_Framework_TestCase
                 'theme' => 'white'
             ),
         ));
-
-        $this->assertEquals(array(
-            'theme' => 'white',
-        ), $this->builder->getAttribute('widget_options'));
 
         $this->assertTrue($this->builder->has('recaptcha_challenge_field'));
         $this->assertTrue($this->builder->has('recaptcha_response_field'));
@@ -68,7 +64,11 @@ class RecaptchaFormTypeTest extends \PHPUnit_Framework_TestCase
             'theme' => 'white',
         ));
 
-        $this->type->buildView($view, $this->builder->getForm(), array());
+        $this->type->buildView($view, $this->builder->getForm(), array(
+                'widget_options' => array(
+                    'theme' => 'white'
+                ),
+            ));
 
         $this->assertEquals('publicKey', $view->vars['public_key']);
         $this->assertEquals(array(

--- a/Tests/Form/Type/RecaptchaTypeTest.php
+++ b/Tests/Form/Type/RecaptchaTypeTest.php
@@ -33,11 +33,14 @@ class RecaptchaFormTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultOptions()
     {
-        /*$this->assertEquals(array(
+        $options = new \Symfony\Component\OptionsResolver\OptionsResolver();
+        $this->type->setDefaultOptions($options);
+
+        $this->assertEquals(array(
             'property_path' => false,
             'required' => true,
             'widget_options' => array(),
-        ), $this->type->getDefaultOptions(array()));*/
+        ), $options->resolve());
     }
 
     public function testBuildForm()

--- a/Tests/Form/Type/RecaptchaTypeTest.php
+++ b/Tests/Form/Type/RecaptchaTypeTest.php
@@ -43,7 +43,7 @@ class RecaptchaFormTypeTest extends \PHPUnit_Framework_TestCase
     public function testBuildForm()
     {
         $this->type->buildForm($this->builder, array(
-            'widget_options' => array(
+            'attr' => array(
                 'theme' => 'white'
             ),
         ));
@@ -55,7 +55,7 @@ class RecaptchaFormTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->builder->has('recaptcha_challenge_field'));
         $this->assertTrue($this->builder->has('recaptcha_response_field'));
         
-        $transformers = $this->builder->getClientTransformers();
+        $transformers = $this->builder->getViewTransformers();
         $this->assertEquals(1, count($transformers));
         $this->assertInstanceOf('SimpleThings\FormExtraBundle\Form\DataTransformer\RecaptchaTransformer', $transformers[0]);
     }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }],
     "require": {
         "php": ">=5.3.0",
-        "symfony/symfony" : ">=2.0"
+        "symfony/symfony" : "~2.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
getAttribute() is deprecated since version 2.1 and will be removed in 2.3. Use getConfig() and FormConfigInterface::getAttribute() instead.
