### PR TITLE
Fix FieldTypeHelpExtension deprecated warnings in Symfony 2.1

### DIFF
--- a/Form/Extension/FieldTypeHelpExtension.php
+++ b/Form/Extension/FieldTypeHelpExtension.php
@@ -26,7 +26,7 @@ class FieldTypeHelpExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['help'] = $form->getConfig()->getAttribute('help');
+        $view->vars['help'] = $options['help'];
     }
 
     /**

--- a/Form/Extension/FieldTypeHelpExtension.php
+++ b/Form/Extension/FieldTypeHelpExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class FieldTypeHelpExtension extends AbstractTypeExtension
 {
@@ -25,17 +26,17 @@ class FieldTypeHelpExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->set('help', $form->getAttribute('help'));
+        $view->vars['help'] = $form->getConfig()->getAttribute('help');
     }
 
     /**
-     * @return array
+     * @param OptionsResolverInterface $resolver
      */
-    public function getDefaultOptions()
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        return array(
+        $resolver->setDefaults(array(
             'help' => null,
-        );
+        ));
     }
 
     /**


### PR DESCRIPTION
This pull request fixes the following warning messages:

```
DEPRECATION - getDefaultOptions() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.
DEPRECATION - getAttribute() is deprecated since version 2.1 and will be removed in 2.3. Use getConfig() and FormConfigInterface::getAttribute() instead.
DEPRECATION - set() is deprecated since version 2.1 and will be removed in 2.3. Access the public property 'vars' instead.
```
