### PR TITLE
Default base_path by base_url and web root dir

### DIFF
--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -22,6 +22,14 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class ImageType extends AbstractType
 {
+    /** @var string */
+    private $webDir;
+
+    public function __construct($kernelDir)
+    {
+        $this->webDir = realpath($kernelDir . '/../web');
+    }
+
     /**
      * Configures the Type
      *
@@ -30,9 +38,6 @@ class ImageType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (!isset($options['base_path']) || !$options['base_path']) {
-            throw new \InvalidArgumentException("Base Path has to be configured.");
-        }
         if (!isset($options['base_uri']) || !$options['base_uri']) {
             throw new \InvalidArgumentException("Base Uri has to be configured.");
         }
@@ -46,6 +51,9 @@ class ImageType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
+        if (!isset($options['base_path']) || !$options['base_path']) {
+            $options['base_path'] = $this->webDir . $options['base_uri'];
+        }
         $data = $form->getData();
 
         if ($data && (strpos(realpath($data->getPath()), realpath($options['base_path'])) === 0)) {

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -25,9 +25,9 @@ class ImageType extends AbstractType
     /** @var string */
     private $webDir;
 
-    public function __construct($kernelDir)
+    public function __construct($webDir)
     {
-        $this->webDir = realpath($kernelDir . '/../web');
+        $this->webDir = realpath($webDir);
     }
 
     /**

--- a/Resources/config/form_extra.xml
+++ b/Resources/config/form_extra.xml
@@ -8,6 +8,7 @@
         <parameter key="simple_things_form_extra.form.type.image.class">SimpleThings\FormExtraBundle\Form\Type\ImageType</parameter>
         <parameter key="simple_things_form_extra.form.type.plain.class">SimpleThings\FormExtraBundle\Form\Type\PlainType</parameter>
         <parameter key="simple_things_form_extra.form.type.file_set.class">SimpleThings\FormExtraBundle\Form\Type\FileSetType</parameter>
+        <parameter key="simple_things_form_extra.web_dir">%kernel.root_dir%/../web</parameter>
     </parameters>
 
     <services>
@@ -16,7 +17,7 @@
         </service>
 
         <service id="simple_things_form_extra.form.type.image" class="%simple_things_form_extra.form.type.image.class%">
-            <argument type="string">%kernel.root_dir%/../web</argument>
+            <argument type="string">%simple_things_form_extra.web_dir%</argument>
             <tag name="form.type" alias="formextra_image" />
         </service>
 

--- a/Resources/config/form_extra.xml
+++ b/Resources/config/form_extra.xml
@@ -16,6 +16,7 @@
         </service>
 
         <service id="simple_things_form_extra.form.type.image" class="%simple_things_form_extra.form.type.image.class%">
+            <argument type="string">%kernel.root_dir%</argument>
             <tag name="form.type" alias="formextra_image" />
         </service>
 

--- a/Resources/config/form_extra.xml
+++ b/Resources/config/form_extra.xml
@@ -16,7 +16,7 @@
         </service>
 
         <service id="simple_things_form_extra.form.type.image" class="%simple_things_form_extra.form.type.image.class%">
-            <argument type="string">%kernel.root_dir%</argument>
+            <argument type="string">%kernel.root_dir%/../web</argument>
             <tag name="form.type" alias="formextra_image" />
         </service>
 

--- a/Tests/Form/Type/ImageTypeTest.php
+++ b/Tests/Form/Type/ImageTypeTest.php
@@ -18,7 +18,7 @@ class ImageFormTypeTest extends TypeTestCase
 
     public function setUp()
     {
-        $this->type = new ImageType();
+        $this->type = new ImageType('base');
         parent::setUp();
     }
 


### PR DESCRIPTION
Default base path by base url
Is good way for many standart situation - for one server uses some upload folder in web root.
If use some file storage base path may be change.
It's remove some ugly

```
$builder->add('image', 'image', array(
   'base_path' => $this->getContainer()->getParameter('kernel.root_dir').'/../web' . '/images/',
   'base_uri' => '/images/',
));

```

or some other some code
