### PR TITLE
support gaufrette in image type

### DIFF
--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -48,9 +48,13 @@ class ImageType extends AbstractType
     {
         $data = $form->getData();
 
-        if ($data && (strpos(realpath($data->getPath()), realpath($options['base_path'])) === 0)) {
+        if ($data) {
             /* @var $data SplFileInfo */
-            $uri = str_replace(realpath($options['base_path']), $options['base_uri'], $data->getRealPath());
+            if (strpos(realpath($data->getPath()), realpath($options['base_path'])) === 0) {
+                $uri = str_replace(realpath($options['base_path']), $options['base_uri'], $data->getRealPath());
+            } else {
+                $uri = str_replace($options['base_path'], $options['base_uri'], $data->getPathname());
+            }
             if ('/' !== DIRECTORY_SEPARATOR) {
                 $uri = str_replace(DIRECTORY_SEPARATOR, '/', $uri);
             }


### PR DESCRIPTION
all reappath functions work only on filesystem, and need only there
but if base path is some like 'gaufrette://images' ?
