### PR TITLE
Help option support for Symfony 2.3

### DIFF
--- a/Form/Extension/FieldTypeHelpExtension.php
+++ b/Form/Extension/FieldTypeHelpExtension.php
@@ -44,6 +44,6 @@ class FieldTypeHelpExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'field';
+        return 'form';
     }
 }

--- a/Resources/config/field_type_help.xml
+++ b/Resources/config/field_type_help.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="simple_things_form_extra.form.extension.help" class="%simple_things_form_extra.form.extension.help.class%">
-            <tag name="form.type_extension" alias="field" />
+            <tag name="form.type_extension" alias="form" />
         </service>
 
     </services>


### PR DESCRIPTION
Small revisions to support the 'help' form field option in Symfony 2.3.
