### PR TITLE
property_path deprecated at false

### DIFF
--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -97,7 +97,7 @@ class RecaptchaType extends AbstractType
     {
         $resolver->setDefaults(array(
             'required'        => true,
-            'property_path'   => false,
+            'mapped'          => false,
             'widget_options'  => array(),
         ));
     }


### PR DESCRIPTION
Since 2.1, the mapped option has been added for this use-case. (http://symfony.com/doc/2.3/reference/forms/types/form.html#property-path)
