### PR TITLE
Don't output an empty help block

### DIFF
--- a/Resources/views/Form/field_type_help.html.twig
+++ b/Resources/views/Form/field_type_help.html.twig
@@ -1,7 +1,7 @@
 {# Widgets #}
 
 {% block field_help %}
-    {% if help is defined %}
+    {% if help|default %}
         <span class="help">{{ help }}</span>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Prevent an empty help block from rendering if help is either undefined or is an empty string.
