### PR TITLE
Remove unused Twig block

### DIFF
--- a/Resources/views/Form/translation_domain.html.twig
+++ b/Resources/views/Form/translation_domain.html.twig
@@ -1,21 +1,5 @@
 {# Widgets #}
 
-{% block widget_choice_options %}
-{% spaceless %}
-    {% for choice, label in options %}
-        {% if _form_is_choice_group(label) %}
-            <optgroup label="{{ choice|trans({}, translation_domain) }}">
-                {% for nestedChoice, nestedLabel in label %}
-                    <option value="{{ nestedChoice }}"{% if _form_is_choice_selected(form, nestedChoice) %} selected="selected"{% endif %}>{{ nestedLabel|trans({}, translation_domain) }}</option>
-                {% endfor %}
-            </optgroup>
-        {% else %}
-            <option value="{{ choice }}"{% if _form_is_choice_selected(form, choice) %} selected="selected"{% endif %}>{{ label|trans({}, translation_domain) }}</option>
-        {% endif %}
-    {% endfor %}
-{% endspaceless %}
-{% endblock widget_choice_options %}
-
 {% block choice_widget %}
 {% spaceless %}
     {% if expanded %}


### PR DESCRIPTION
I'm pretty sure this block is no longer used since Assetic always throws

```
The template "SimpleThingsFormExtraBundle:Form:translation_domain.html.twig" contains an error: The function "_form_is_choice_group" does not exist in "SimpleThingsFormExtraBundle:Form:translation_domain.html.twig" at line 6
```

for every dump.

Fixes #51 
